### PR TITLE
Allow react 15 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "webpack": "^1.11.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
+    "react": "^0.14.0 || ^15.0.0-0",
     "redux-devtools": "^3.0.0"
   }
 }


### PR DESCRIPTION
React 15 is out, and this fixes the peer dependency warning. :+1: 
