### PR TITLE
Fix “Warning: Accessing PropTypes via the main React package is depre…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-devtools-filter-actions",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A composable monitor for Redux DevTools with the ability to filter actions.",
   "main": "lib/index.js",
   "files": [
@@ -47,6 +47,7 @@
     "expect": "^1.6.0",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
+    "prop-types": "^15.5.8",
     "rimraf": "^2.3.4",
     "webpack": "^1.11.0"
   },

--- a/src/FilterMonitor.js
+++ b/src/FilterMonitor.js
@@ -1,4 +1,5 @@
-import { cloneElement, Component, PropTypes } from 'react';
+import { cloneElement, Component } from 'react';
+import PropTypes from 'prop-types';
 import mapValues from 'lodash/mapValues';
 import reducer from './reducers';
 


### PR DESCRIPTION
…cated. Use the prop-types package from npm instead.”